### PR TITLE
fix: resolve ruff lint errors

### DIFF
--- a/functional_tests.py
+++ b/functional_tests.py
@@ -18,10 +18,10 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "sample.settings")
 django.setup()
 
 # Use playwright
-from playwright.sync_api import sync_playwright
-from playwright._impl._errors import TimeoutError
+from playwright.sync_api import sync_playwright  # noqa: E402
+from playwright._impl._errors import TimeoutError  # noqa: E402
 
-from django.contrib.auth import get_user_model
+from django.contrib.auth import get_user_model  # noqa: E402
 
 USERNAME = "testuser"
 PASSWORD = "Testpassword123"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-fitbit-healthkit"
-version = "0.6.1"
+version = "0.6.2"
 description = "A Django app to access Fitbit Web APIs."
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Fix E402 lint errors in functional_tests.py by adding noqa comments — imports must come after Django environment setup.