### PR TITLE
chore: monthly maintenance — March 2026

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "django-fitbit-healthkit"
-version = "0.6"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
Automated monthly maintenance for **django-fitbit-healthkit**.

### Steps
- ✅ pre-commit autoupdate
- ✅ pre-commit run --all-files
- ✅ uv lock --upgrade
- ✅ uv sync
- ✅ uv run pytest

Dependency lag date: `2026-03-06`

Generated by `maintain.py` on 2026-03-13.