### PR TITLE
Deprecate: Fitbit Web API sunset (Sept 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # django-fitbit-healthkit
 
+> ## ⚠️ DEPRECATED — Fitbit Web API is being shut down
+>
+> Google is [retiring the Fitbit Web API](https://dev.fitbit.com/build/reference/web-api/developer-updates/)
+> in **September 2026**. After that date this package will no longer function and will be archived.
+>
+> **What that means for users of this package:**
+> - Through the Fitbit Web API sunset (~September 2026), this project will receive
+>   **security updates only** — no new features.
+> - After the API is shut down, the GitHub repository will be archived and the PyPI
+>   release will be left in place but marked deprecated.
+> - If you are starting a new integration, do not adopt this package — pick a
+>   data source that will still exist after September 2026.
+>
+> If you depend on Fitbit data going forward, plan a migration off the Fitbit Web API now.
+
 django-fitbit-healthkit is a Django Fitbit App with HealthKit-friendly API.
 The goal is to provide a wrapper over fitbit authentication, token management, and web APIs
 that is similar to other high-level healthkit wrappers like [react-native-healthkit](https://github.com/kingstinct/react-native-healthkit).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-fitbit-healthkit"
-version = "0.6.2"
+version = "0.6.3"
 description = "A Django app to access Fitbit Web APIs."
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -12,6 +12,7 @@ authors = [
     { name = "Andy Reagan", email = "andy@andyreagan.com" },
 ]
 classifiers = [
+    "Development Status :: 7 - Inactive",
     "Environment :: Web Environment",
     "Framework :: Django",
     "Framework :: Django :: 5.0",


### PR DESCRIPTION
## Summary
- Google is retiring the [Fitbit Web API](https://dev.fitbit.com/build/reference/web-api/developer-updates/) in **September 2026**, after which this package can no longer function.
- Adds a visible deprecation banner at the top of `README.md` so anyone landing on PyPI or GitHub sees the sunset before adopting the package.
- Marks the package `Development Status :: 7 - Inactive` in `pyproject.toml` classifiers.
- Bumps version `0.6.2 → 0.6.3` so the deprecation notice ships to PyPI on the next tag.

## Lifecycle going forward
- **Now → Fitbit Web API shutdown (~Sept 2026):** security updates only, no new features.
- **After shutdown:** archive the GitHub repo; leave the PyPI release in place but deprecated.

## Test plan
- [ ] CI passes on the PR
- [ ] After merge, `./tag-releases.sh django-fitbit-healthkit` to push `v0.6.3` and trigger PyPI publish
- [ ] Verify the rendered deprecation banner on the new PyPI release page